### PR TITLE
fix(config): align repository name to 'boba'

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,16 +171,16 @@ git rebase main
 
 ## 5. Deployment (GitHub Pages)
 
-This project is configured for deployment to GitHub Pages under a repository-named subdirectory (e.g., `https://<username>.github.io/boba-templater/`).
+This project is configured for deployment to GitHub Pages under a repository-named subdirectory (e.g., `https://<username>.github.io/boba/`).
 
-*   **Base Path:** The `vite.config.ts` file sets `base: '/boba-templater/'` during production builds (`command === 'build'`). This ensures that `import.meta.env.BASE_URL` is correctly set to `/boba-templater/`, and all asset paths in the built `index.html` are prefixed accordingly.
+*   **Base Path:** The `vite.config.ts` file sets `base: '/boba/'` during production builds (`command === 'build'`). This ensures that `import.meta.env.BASE_URL` is correctly set to `/boba/`, and all asset paths in the built `index.html` are prefixed accordingly.
 *   **SPA Routing (404.html Strategy):** To support deep linking in the SPA on GitHub Pages, the `.github/workflows/deploy.yml` workflow includes a step: `cp dist/index.html dist/404.html`. This means GitHub Pages will serve the application's main `index.html` file for any path it doesn't directly recognize, allowing the client-side router to handle the specific route.
 
 ## 6. Routing
 
 *   Client-side routing is handled by the `Router` class in `src/core/router/router.ts`.
 *   Routes are defined and registered in `src/main.ts` using `Router.getInstance().registerRoute({...});`.
-*   The router uses `import.meta.env.BASE_URL` (provided by Vite, see "Deployment" section) to correctly determine the application-specific path from `window.location.pathname`. For example, if `BASE_URL` is `/boba-templater/` and `window.location.pathname` is `/boba-templater/about`, the router will correctly identify the application path as `/about`.
+*   The router uses `import.meta.env.BASE_URL` (provided by Vite, see "Deployment" section) to correctly determine the application-specific path from `window.location.pathname`. For example, if `BASE_URL` is `/boba/` and `window.location.pathname` is `/boba/about`, the router will correctly identify the application path as `/about`.
 
 ## 7. Component Structure
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "boba-templater",
+  "name": "boba",
   "version": "1.0.0",
   "type": "module",
   "main": "./src/main.ts",
-  "homepage": "https://sholtomaud.github.io/boba-templater/",
+  "homepage": "https://sholtomaud.github.io/boba/",
   "scripts": {
     "dev": "NODE_ENV=development vite",
     "dev:host": "vite --host",

--- a/src/components/home-page/home.html
+++ b/src/components/home-page/home.html
@@ -24,8 +24,8 @@
         Clone the repository and start building your next web application:
       </p>
       <code class="code-block">
-        git clone https://github.com/sholtomaud/boba-templater.git <br>
-        cd boba-templater <br>
+        git clone https://github.com/sholtomaud/boba.git <br>
+        cd boba <br>
         npm install <br>
         npm run dev
       </code>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import { resolve } from 'path';
 import componentManifest from './vite-plugin-component-manifest';
 
 export default defineConfig(({ command }) => ({
-  base: command === 'build' ? '/boba-templater/' : '/',
+  base: command === 'build' ? '/boba/' : '/',
   plugins: [componentManifest()],
   build: {
     outDir: 'dist',


### PR DESCRIPTION
This commit corrects the repository name in all configuration and documentation files to use `boba`, following your feedback. This ensures that the GitHub Pages deployment will work as expected.

- Updated `package.json` to set the package name and homepage URL based on `boba`.
- Updated `vite.config.ts` to set the `base` deployment path to `/boba/`.
- Updated the `git clone` example in the homepage to use the correct repository URL.
- Updated repository name references in `AGENTS.md` to match.